### PR TITLE
Explicitly use -jessie as base until we move to -stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.1-apache-jessie
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.


### PR DESCRIPTION
Recently the official builds moved the default from jessie to stretch
so, some of the dependencies in our container stopped working.

This just ensures that we continue using the -jessie variants until
the move to -stretch (and dependencies) are tested enough.

Part of #21.