### PR TITLE
Add xdebug support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ RUN chmod 777 /tmp && chmod +t /tmp
 RUN /tmp/setup/php-extensions.sh
 RUN /tmp/setup/oci8-extension.sh
 
+RUN chmod +x /usr/bin/moodle-php-entrypoint
+ENTRYPOINT ["moodle-php-entrypoint"]
+
 RUN mkdir /var/www/moodledata && chown www-data /var/www/moodledata && \
     mkdir /var/www/phpunitdata && chown www-data /var/www/phpunitdata && \
     mkdir /var/www/behatdata && chown www-data /var/www/behatdata && \
     mkdir /var/www/behatfaildumps && chown www-data /var/www/behatfaildumps
+
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ To faciliate testing and easy setup the following directories are created and ow
 * `/var/www/behatdata`
 * `/var/www/behatfaildumps`
 
+# Xdebug
+
+For development, the image contains the Xdebug PHP extension. This is disabled by default, for performance reasons, but can be enabled by setting a non-empty XDEBUG_CONFIG environment variable. This environment variable is also used by Xdebug for configuration (see [XDebug documentation](https://xdebug.org/docs) for details and available configuration settings).
+
+```bash
+$ docker run --name web0 -p 8080:80  -v $PWD:/var/www/html -e XDEBUG_CONFIG="remote_enable=1 remote_connect_back=1" moodlehq/moodle-php-apache:7.1
+```
 
 # See also
 This container is part of a set of containers for Moodle development, see also:

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -48,6 +48,8 @@ ACCEPT_EULA=Y apt-get install -y msodbcsql
 pecl install sqlsrv-4.3.0
 docker-php-ext-enable sqlsrv
 
+pecl install xdebug-2.6.1
+
 # Keep our image size down..
 pecl clear-cache
 apt-get remove --purge -y $BUILD_PACKAGES

--- a/root/usr/bin/moodle-php-entrypoint
+++ b/root/usr/bin/moodle-php-entrypoint
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+XDEBUG_INI_FILE=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+if [ -z "${XDEBUG_CONFIG}" ]; then
+    rm -f $XDEBUG_INI_FILE
+else
+    if [ ! -e $XDEBUG_INI_FILE ]; then
+        # Enable the extension.
+        echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > $XDEBUG_INI_FILE
+        # Configure the main settings, keeping features disabled.
+        cat <<EOF >> $XDEBUG_INI_FILE
+# Code coverage.
+xdebug.coverage_enable = 0
+# Stack trace.
+xdebug.default_enable = 0
+# Remote debug.
+xdebug.remote_enable = 0
+xdebug.remote_host = localhost
+xdebug.remote_port = 9000
+xdebug.remote_autostart = 1
+# Profiling: https://docs.moodle.org/dev/Profiling_PHP#Quick_summary
+xdebug.profiler_enable = 0
+xdebug.profiler_enable_trigger = 0
+xdebug.profiler_output_dir = /tmp
+xdebug.profiler_output_name = cachegrind.out.%R.%u
+EOF
+    fi
+fi
+
+/usr/local/bin/docker-php-entrypoint "$@"


### PR DESCRIPTION
Here's a patch for xdebug support (#17). It installs the module but leaves it disabled. The module will be enabled if there is a non-empty XDEBUG_CONFIG environment variable.

I thought it would be better to use the existing XDEBUG_CONFIG environment variable rather than introduce a new one, as realistically you're likely to want to configure xdebug if you enable it. In the event that someone wants it to run with all the default settings - which will probably be rare - you can just pass one of the default settings to enable it (e.g. XDEBUG_CONFIG="default_enable=1")