### PR TITLE
7.1 stretch pcrejit

### DIFF
--- a/root/usr/local/etc/php/conf.d/mdl-65594.ini
+++ b/root/usr/local/etc/php/conf.d/mdl-65594.ini
@@ -1,0 +1,3 @@
+[Pcre]
+; Disable JIT PCRE because it seems to cause random segfaults in PHP 7.1.
+pcre.jit=0


### PR DESCRIPTION
This commit disables pcre.jit. Unfortunately this is not easy to do at runtime due to the fact that mounting individual files in docker has limited support. This addresses segfaults discovered in MDL-65594.