### PR TITLE
Enable the mongodb extension for 7.2

### DIFF
--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -60,7 +60,7 @@ docker-php-ext-install -j$(nproc) ldap
 
 # Memcached, MongoDB, Redis, APCu, igbinary.
 pecl install memcached mongodb redis apcu igbinary
-docker-php-ext-enable memcached redis apcu igbinary
+docker-php-ext-enable memcached mongodb redis apcu igbinary
 
 # ZIP
 docker-php-ext-configure zip --with-libzip

--- a/tests/fixtures/test.php
+++ b/tests/fixtures/test.php
@@ -7,6 +7,7 @@ $requiredextensions = [
     'intl',
     'ldap',
     'memcached',
+    'mongodb',
     'mysqli',
     'oci8',
     'pgsql',


### PR DESCRIPTION
Just that, nothing else needs to be done. moolde-docker will have
other changes to make the test environment ready.

This is part of #16 

Unit tests are passing ok with 37_STABLE and master:

````
$ bin/moodle-docker-compose exec webserver vendor/bin/phpunit --testsuite cachestore_mongodb_testsuite -v
Moodle 3.7+ (Build: 20190524), e39f3b7db215b61d68ea2a23ff850f0efa1853e8
Php: 7.2.18, pgsql: 9.6.7, OS: Linux 4.9.125-linuxkit x86_64
PHPUnit 7.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.18
Configuration: /var/www/html/phpunit.xml

..                                                                  2 / 2 (100%)

Time: 4 seconds, Memory: 52.00 MB

OK (2 tests, 42 assertions)
````

And being skipped with previous Moodle versions (where [MDL-54592](https://tracker.moodle.org/browse/MDL-54592)) was not implemented:

````
$ bin/moodle-docker-compose exec webserver vendor/bin/phpunit --testsuite cachestore_mongodb_testsuite -v
Moodle 3.6.4+ (Build: 20190524), baebbcc341e44dc5552d54a2be8c6fdd3cf4d9c8
Php: 7.3.5, pgsql: 9.6.7, OS: Linux 4.9.125-linuxkit x86_64
PHPUnit 6.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.5
Configuration: /var/www/html/phpunit.xml

SS                                                                  2 / 2 (100%)

Time: 4.45 seconds, Memory: 48.00MB

There were 2 skipped tests:

1) cachestore_mongodb_test::test_collection_name
Could not test cachestore_mongodb. Requirements are not met.

/var/www/html/cache/tests/fixtures/stores.php:52
/var/www/html/lib/phpunit/classes/advanced_testcase.php:80

To re-run:
 vendor/bin/phpunit -v "cachestore_mongodb_test" cache/stores/mongodb/tests/mongodb_test.php

2) cachestore_mongodb_test::test_test_instance
Could not test cachestore_mongodb. Requirements are not met.

/var/www/html/cache/tests/fixtures/stores.php:52
/var/www/html/lib/phpunit/classes/advanced_testcase.php:80

To re-run:
 vendor/bin/phpunit -v "cachestore_mongodb_test" cache/stores/mongodb/tests/mongodb_test.php

OK, but incomplete, skipped, or risky tests!
Tests: 2, Assertions: 0, Skipped: 2.
````
