### PR TITLE
Exactly the same than php71's #56, but applied to php70

### DIFF
--- a/root/usr/local/etc/php/conf.d/mdl-65594.ini
+++ b/root/usr/local/etc/php/conf.d/mdl-65594.ini
@@ -1,0 +1,3 @@
+[Pcre]
+; Disable JIT PCRE because it seems to cause random segfaults in PHP 7.0.
+pcre.jit=0


### PR DESCRIPTION
We are getting a good number of segmentation faults in the
new jobs (lowest) using php70 and have found various reports about
the pcre jit compiler also causing problems with php70.

So, proceeding (and crossing fingers).