### PR TITLE
Let's remain sticky to Redis 4.3.0 (php71)

### DIFF
--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -59,7 +59,7 @@ docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
 # SOLR, Memcached, Redis, APCu, igbinary.
-pecl install solr memcached mongodb redis apcu igbinary
+pecl install solr memcached mongodb redis-4.3.0 apcu igbinary
 docker-php-ext-enable solr memcached mongodb redis apcu igbinary
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini


### PR DESCRIPTION
Some days ago Redis 5.0.0 was released and it includes some
changes that require verification in core functionality and
associated unit tests (now failing). To be handled by:

https://tracker.moodle.org/browse/MDL-66139

Once that issue is fixed... surely we can unpin this.

Ciao :-)