### PR TITLE
Let's remain sticky to Redis 4.3.0 (php73-buster)

### DIFF
--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -59,7 +59,7 @@ docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
 # Memcached, MongoDB, Redis, APCu, igbinary.
-pecl install memcached mongodb redis apcu igbinary
+pecl install memcached mongodb redis-4.3.0 apcu igbinary
 docker-php-ext-enable memcached mongodb redis apcu igbinary
 
 # ZIP


### PR DESCRIPTION
Some days ago Redis 5.0.0 was released and it includes some
changes that require verification in core functionality and
associated unit tests (now failing). To be handled by:

https://tracker.moodle.org/browse/MDL-66139

Once that issue is fixed... surely we can unpin this.

Ciao :-)