### PR TITLE
Unpin Redis 4.3.0. Newer >= 5.0.0 versions should be back to work (7.1-stretch)

### DIFF
--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -59,7 +59,7 @@ docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
 # SOLR, Memcached, Redis, APCu, igbinary.
-pecl install solr memcached mongodb redis-4.3.0 apcu igbinary
+pecl install solr memcached mongodb redis apcu igbinary
 docker-php-ext-enable solr memcached mongodb redis apcu igbinary
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini


### PR DESCRIPTION
Once https://tracker.moodle.org/browse/MDL-66139 is rolled. Part of #77 