### PR TITLE
Make php70 solr extension sticky to 2.4.0

### DIFF
--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -59,7 +59,7 @@ docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
 # SOLR, Memcached, Redis, APCu, igbinary.
-pecl install solr memcached redis apcu igbinary
+pecl install solr-2.4.0 memcached redis apcu igbinary
 docker-php-ext-enable solr memcached redis apcu igbinary
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini


### PR DESCRIPTION
Only was affecting 35_STABLE, I don't understand / remember
why. The very same php70 image (using solr 2.5.0) is passing
perfectly with 36_STABLE.

In any case, downgrading fixes it and given, php70 is EOL, this
quick fix is enough to get 35_STABLE back to pass.