### PR TITLE
Add Xdebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,13 @@ RUN mkdir /var/www/moodledata && chown www-data /var/www/moodledata && \
     mkdir /var/www/phpunitdata && chown www-data /var/www/phpunitdata && \
     mkdir /var/www/behatdata && chown www-data /var/www/behatdata && \
     mkdir /var/www/behatfaildumps && chown www-data /var/www/behatfaildumps
+
+ARG XDEBUG=0
+ARG XDEBUG_VERSION=2.7.2
+ARG XDEBUG_PORT=9000
+ARG XDEBUG_REMOTE_HOST=docker.for.mac.host.internal
+RUN /tmp/setup/xdebug-extension.sh \
+    -d $XDEBUG \
+    -v $XDEBUG_VERSION \
+    -p $XDEBUG_PORT \
+    -h $XDEBUG_REMOTE_HOST

--- a/root/tmp/setup/xdebug-extension.sh
+++ b/root/tmp/setup/xdebug-extension.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage() { echo "Usage: $0 -d <debug> -v <Xdebug version> -p <port> -h <remote host>" 1>&2; exit 1; }
+
+while getopts ":d:v:p:h:" o; do
+    case "${o}" in
+        d)
+            DEBUG=${OPTARG}
+            ;;
+        v)
+            VERSION=${OPTARG}
+            ;;
+        p)
+            PORT=${OPTARG}
+            ;;
+        h)
+            REMOTE_HOST=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+echo $DEBUG
+echo $VERSION
+echo $PORT
+echo $REMOTE_HOST
+
+
+if [[ -z $DEBUG ]] || [[ -z $VERSION ]] || [[ -z $PORT ]] || [[ -z $REMOTE_HOST ]]; then 
+    usage 
+fi
+
+if [ $DEBUG == 1 ]; then
+  
+    XDEBUG_INI_FILE=/usr/local/etc/php/conf.d/xdebug.ini
+
+    # Install Xdebug
+    echo "Installing Xdebug"
+    pecl install xdebug-$VERSION
+    docker-php-ext-enable xdebug
+
+    # Adding Xdebug log file
+    mkdir /var/log/xdebug
+    touch /var/log/xdebug/xdebug.log
+    chmod 777 /var/log/xdebug/xdebug.log
+
+    # Adding Xdebug INI file
+    cat <<EOF >> $XDEBUG_INI_FILE
+    zend_extension=xdebug.so
+    xdebug.remote_enable=1
+    xdebug.remote_handler=dbgp
+    xdebug.remote_mode=req
+    xdebug.remote_host=$REMOTE_HOST
+    xdebug.remote_port=$PORT
+    xdebug.remote_log=/var/log/xdebug/xdebug.log
+EOF
+fi


### PR DESCRIPTION
This is a small change to activate Xdebug via the docker build command.

This is the build command:
docker build -t moodlehq/moodle-php-apache:7.3 --build-arg XDEBUG=1 .
or
docker build -t moodlehq/moodle-php-apache:7.3-xdebug --build-arg XDEBUG=1 .

We can override the arguments:
docker build -t moodlehq/moodle-php-apache:7.3 --build-arg XDEBUG=1 --build-arg XDEBUG_REMOTE_HOST=0.0.0.0 --build-arg XDEBUG_VERSION=2.8.0 .

Thank you for your comments.
Ali
