### PR TITLE
7.4 buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.0beta4-apache-buster
+FROM php:7.4.0RC1-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.0RC6-apache-buster
+FROM php:7.4-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.0beta1-apache-buster
+FROM php:7.4.0beta4-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.0alpha3-apache-buster
+FROM php:7.4.0beta1-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.0RC3-apache-buster
+FROM php:7.4.0RC6-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache-buster
+FROM php:7.4.0alpha3-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.0RC1-apache-buster
+FROM php:7.4.0RC3-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Moodle PHP environment configured for Moodle development based on [Official PH
 
 | PHP Version  | Variant | Tags             | Status |
 |--------------|---------|------------------|--------|
-| PHP 7.4beta4 | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
+| PHP 7.4rc3   | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
 
 For a complete list of supported versions, look to the [master README](https://github.com/moodlehq/moodle-php-apache/tree/master).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Moodle PHP environment configured for Moodle development based on [Official PH
 
 | PHP Version  | Variant | Tags             | Status |
 |--------------|---------|------------------|--------|
-| PHP 7.4rc3   | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
+| PHP 7.4rc6   | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
 
 For a complete list of supported versions, look to the [master README](https://github.com/moodlehq/moodle-php-apache/tree/master).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Moodle PHP environment configured for Moodle development based on [Official PH
 
 | PHP Version  | Variant | Tags             | Status |
 |--------------|---------|------------------|--------|
-| PHP 7.3      | Buster  | 7.3-buster       | [![Build Status](https://travis-ci.org/moodlehq/moodle-php-apache.svg?branch=7.3-buster)](https://travis-ci.org/moodlehq/moodle-php-apache)|
+| PHP 7.4beta1 | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
 
 For a complete list of supported versions, look to the [master README](https://github.com/moodlehq/moodle-php-apache/tree/master).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Moodle PHP environment configured for Moodle development based on [Official PH
 
 | PHP Version  | Variant | Tags             | Status |
 |--------------|---------|------------------|--------|
-| PHP 7.4beta1 | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
+| PHP 7.4beta4 | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
 
 For a complete list of supported versions, look to the [master README](https://github.com/moodlehq/moodle-php-apache/tree/master).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Moodle PHP environment configured for Moodle development based on [Official PH
 
 | PHP Version  | Variant | Tags             | Status |
 |--------------|---------|------------------|--------|
-| PHP 7.4rc6   | Buster  | 7.4-buster       | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
+| PHP 7.4      | Buster  | 7.4, 7.4-buster  | [![Build Status](https://travis-ci.org/stronk7/moodle-php-apache.svg?branch=7.4-buster)](https://travis-ci.org/stronk7/moodle-php-apache)|
 
 For a complete list of supported versions, look to the [master README](https://github.com/moodlehq/moodle-php-apache/tree/master).
 

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# A space-separated list of additional tags to place on this image.
+additionalTags=(7.4)
+
+# Tag and push image for each additional tag
+for tag in ${additionalTags[@]}; do
+    echo "Tagging {$IMAGE_NAME} as ${DOCKER_REPO}:${tag}"
+    docker tag $IMAGE_NAME ${DOCKER_REPO}:${tag}
+
+    echo "Pushing ${DOCKER_REPO}:${tag}"
+    docker push ${DOCKER_REPO}:${tag}
+done

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -84,7 +84,9 @@ echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
 # Install Microsoft dependencies for sqlsrv.
 # (kept apart for clarity, still need to be run here
 # before some build packages are deleted)
-/tmp/setup/sqlsrv-extension.sh
+# NOTE: As of 20190727 5.6.1 does not build with php7.4beta1, so commented out.
+# Link: https://github.com/microsoft/msphpsql/issues/999
+# /tmp/setup/sqlsrv-extension.sh
 
 # Keep our image size down..
 pecl clear-cache

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -59,7 +59,7 @@ docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
 # Memcached, MongoDB, Redis, APCu, igbinary.
-pecl install memcached mongodb redis-4.3.0 apcu igbinary
+pecl install memcached mongodb redis apcu igbinary
 docker-php-ext-enable memcached mongodb redis apcu igbinary
 
 # ZIP

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -84,11 +84,7 @@ echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
 # Install Microsoft dependencies for sqlsrv.
 # (kept apart for clarity, still need to be run here
 # before some build packages are deleted)
-# NOTE: As of 20190727 5.6.1 does not build with php7.4beta1, so commented out.
-# NOTE: As of 20190827 5.6.1 does not build with php7.4beta4, so commented out.
-# The underlying issue has been fixed but there isn't any > 5.6.1 release including it.
-# Link: https://github.com/microsoft/msphpsql/issues/999
-# /tmp/setup/sqlsrv-extension.sh
+/tmp/setup/sqlsrv-extension.sh
 
 # Keep our image size down..
 pecl clear-cache

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -51,7 +51,7 @@ docker-php-ext-install -j$(nproc) \
     xmlrpc
 
 # GD.
-docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/
 docker-php-ext-install -j$(nproc) gd
 
 # LDAP.
@@ -63,7 +63,7 @@ pecl install memcached mongodb redis apcu igbinary
 docker-php-ext-enable memcached mongodb redis apcu igbinary
 
 # ZIP
-docker-php-ext-configure zip --with-libzip
+docker-php-ext-configure zip --with-zip
 docker-php-ext-install zip
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -7,7 +7,7 @@ echo "Installing apt dependencies"
 # Build packages will be added during the build, but will be removed at the end.
 BUILD_PACKAGES="gettext gnupg libcurl4-openssl-dev libfreetype6-dev libicu-dev libjpeg62-turbo-dev \
   libldap2-dev libmariadbclient-dev libmemcached-dev libpng-dev libpq-dev libxml2-dev libxslt-dev \
-  unixodbc-dev"
+  unixodbc-dev uuid-dev"
 
 # Packages for Postgres.
 PACKAGES_POSTGRES="libpq5"
@@ -59,8 +59,8 @@ docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
 # Memcached, MongoDB, Redis, APCu, igbinary.
-pecl install memcached mongodb redis apcu igbinary
-docker-php-ext-enable memcached mongodb redis apcu igbinary
+pecl install memcached mongodb redis apcu igbinary uuid
+docker-php-ext-enable memcached mongodb redis apcu igbinary uuid
 
 # ZIP
 docker-php-ext-configure zip --with-zip

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -85,6 +85,8 @@ echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
 # (kept apart for clarity, still need to be run here
 # before some build packages are deleted)
 # NOTE: As of 20190727 5.6.1 does not build with php7.4beta1, so commented out.
+# NOTE: As of 20190827 5.6.1 does not build with php7.4beta4, so commented out.
+# The underlying issue has been fixed but there isn't any > 5.6.1 release including it.
 # Link: https://github.com/microsoft/msphpsql/issues/999
 # /tmp/setup/sqlsrv-extension.sh
 

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -59,7 +59,7 @@ docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
 # Memcached, MongoDB, Redis, APCu, igbinary.
-pecl install memcached mongodb redis apcu igbinary
+pecl install memcached mongodb redis-4.3.0 apcu igbinary
 docker-php-ext-enable memcached mongodb redis apcu igbinary
 
 # ZIP

--- a/root/tmp/setup/sqlsrv-extension.sh
+++ b/root/tmp/setup/sqlsrv-extension.sh
@@ -15,6 +15,6 @@ ACCEPT_EULA=Y apt-get install -y msodbcsql17
 
 ln -fsv /opt/mssql-tools/bin/* /usr/bin
 
-# Need 5.5.0preview (or later) for PHP 7.3 support
-pecl install sqlsrv-5.6.1
+# Need 5.7.0preview (or later) for PHP 7.4 support
+pecl install sqlsrv-5.7.0preview
 docker-php-ext-enable sqlsrv

--- a/tests/fixtures/test.php
+++ b/tests/fixtures/test.php
@@ -18,6 +18,7 @@ $requiredextensions = [
     'xsl',
     'xmlrpc',
     'zip',
+    'uuid'
 ];
 
 $buffer = '';;


### PR DESCRIPTION
with the release of 7.4.0 we can now make 7.4-buster (and 7.4) public. So creating the branch and adding all the stuff.