### PR TITLE
Minor updates to sqlsrv and oci drivers

### DIFF
--- a/root/tmp/setup/oci8-extension.sh
+++ b/root/tmp/setup/oci8-extension.sh
@@ -3,22 +3,21 @@
 set -e
 
 echo "Downloading oracle files"
-curl https://raw.githubusercontent.com/AminMkh/docker-php7-oci8-apache/b7c740638776552f00178a5d12905cefb50c7848/oracle/instantclient-basic-linux.x64-12.1.0.2.0.zip\
-    -o /tmp/instantclient-basic-linux.x64-12.1.0.2.0.zip
-curl https://raw.githubusercontent.com/AminMkh/docker-php7-oci8-apache/b7c740638776552f00178a5d12905cefb50c7848/oracle/instantclient-sdk-linux.x64-12.1.0.2.0.zip\
-    -o /tmp/instantclient-sdk-linux.x64-12.1.0.2.0.zip
-curl https://raw.githubusercontent.com/AminMkh/docker-php7-oci8-apache/b7c740638776552f00178a5d12905cefb50c7848/oracle/instantclient-sqlplus-linux.x64-12.1.0.2.0.zip\
-    -o /tmp/instantclient-sqlplus-linux.x64-12.1.0.2.0.zip
+curl https://download.oracle.com/otn_software/linux/instantclient/19600/instantclient-basic-linux.x64-19.6.0.0.0dbru.zip \
+    -o /tmp/instantclient-basic-linux.x64-19.6.0.0.0dbru.zip
+curl https://download.oracle.com/otn_software/linux/instantclient/19600/instantclient-sdk-linux.x64-19.6.0.0.0dbru.zip \
+    -o /tmp/instantclient-sdk-linux.x64-19.6.0.0.0dbru.zip
+curl https://download.oracle.com/otn_software/linux/instantclient/19600/instantclient-sqlplus-linux.x64-19.6.0.0.0dbru.zip \
+    -o /tmp/instantclient-sqlplus-linux.x64-19.6.0.0.0dbru.zip
 
-unzip /tmp/instantclient-basic-linux.x64-12.1.0.2.0.zip -d /usr/local/
-rm /tmp/instantclient-basic-linux.x64-12.1.0.2.0.zip
-unzip /tmp/instantclient-sdk-linux.x64-12.1.0.2.0.zip -d /usr/local/
-rm /tmp/instantclient-sdk-linux.x64-12.1.0.2.0.zip
-unzip /tmp/instantclient-sqlplus-linux.x64-12.1.0.2.0.zip -d /usr/local/
-rm /tmp/instantclient-sqlplus-linux.x64-12.1.0.2.0.zip
+unzip /tmp/instantclient-basic-linux.x64-19.6.0.0.0dbru.zip -d /usr/local/
+rm /tmp/instantclient-basic-linux.x64-19.6.0.0.0dbru.zip
+unzip /tmp/instantclient-sdk-linux.x64-19.6.0.0.0dbru.zip -d /usr/local/
+rm /tmp/instantclient-sdk-linux.x64-19.6.0.0.0dbru.zip
+unzip /tmp/instantclient-sqlplus-linux.x64-19.6.0.0.0dbru.zip -d /usr/local/
+rm /tmp/instantclient-sqlplus-linux.x64-19.6.0.0.0dbru.zip
 
-ln -s /usr/local/instantclient_12_1 /usr/local/instantclient
-ln -s /usr/local/instantclient/libclntsh.so.12.1 /usr/local/instantclient/libclntsh.so
+ln -s /usr/local/instantclient_19_6 /usr/local/instantclient
 ln -s /usr/local/instantclient/sqlplus /usr/bin/sqlplus
 
 echo 'instantclient,/usr/local/instantclient' | pecl install oci8 && docker-php-ext-enable oci8

--- a/root/tmp/setup/sqlsrv-extension.sh
+++ b/root/tmp/setup/sqlsrv-extension.sh
@@ -16,5 +16,5 @@ ACCEPT_EULA=Y apt-get install -y msodbcsql17
 ln -fsv /opt/mssql-tools/bin/* /usr/bin
 
 # Need 5.7.0preview (or later) for PHP 7.4 support
-pecl install sqlsrv-5.7.0preview
+pecl install sqlsrv-5.8.1
 docker-php-ext-enable sqlsrv


### PR DESCRIPTION
- sqlsrv: bump to current stable sqlsrv-5.8.1
- oci: switch to current instantclient from oracle official public site.

Note that this doesn't fix MDL-68655, php74 + oracle problems
with this docker image continue happening the same. Follow the
issue for more information.