### PR TITLE
Finally add git to the PHP image (71-buster)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.
 RUN chmod 777 /tmp && chmod +t /tmp
 
+# Install some packages that are useful within the images.
+RUN apt-get update && apt-get install -y \
+    git \
+&& rm -rf /var/lib/apt/lists/*
+
 # Setup the required extensions.
 ARG DEBIAN_FRONTEND=noninteractive
 RUN /tmp/setup/php-extensions.sh


### PR DESCRIPTION
Apart from other uses, we need it because we are using composer
with vcs-repo to be able to use own instaclick, instead of getting
everything from packagist.

That hits Github's API limits and required OAuth tokens or similar,
easy to add locally, but not in CI envs like travis. So, only solution
is to make the php containers able to use the git alternative.

Apart from that, of course, having git within the images enables
some more dev workflows and really doesn't weights much.