### PR TITLE
Install solr extension from source

### DIFF
--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -58,9 +58,9 @@ docker-php-ext-install -j$(nproc) gd
 docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
-# SOLR, Memcached, Redis, APCu, igbinary.
-pecl install solr memcached mongodb redis apcu igbinary uuid
-docker-php-ext-enable solr memcached mongodb redis apcu igbinary uuid
+# Memcached, MongoDB, Redis, APCu, igbinary.
+pecl install memcached mongodb redis apcu igbinary uuid
+docker-php-ext-enable memcached mongodb redis apcu igbinary uuid
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
 
@@ -72,6 +72,19 @@ ACCEPT_EULA=Y apt-get install -y msodbcsql17
 
 pecl install sqlsrv-5.6.1
 docker-php-ext-enable sqlsrv
+
+# Install custom solr extension. Last release (2.4.0) is not working at all
+# with php72 and php73 and upstream has not either! Solution:
+#   - current master (as of 21th May 2019):
+#     https://github.com/php/pecl-search_engine-solr/commit/98a8bf540bcb4e9b2e1378cce2f3a9bf6cd772b8
+#   - this patch, applied already upstream:
+#     https://github.com/php/pecl-search_engine-solr/commit/744e32915d5989101267ed2c84a407c582dc6f31
+# So, following the experience with Macports, and https://bugs.php.net/bug.php?id=75631
+# we are going to try 2.4.0 release + macports patch. Old, but working right now.
+# References:
+#   - https://github.com/moodlehq/moodle-php-apache/issues/16 (part of the php72 image discussion)
+#   - https://github.com/moodlehq/moodle-php-apache/issues/19 (awaiting for a better solution)
+/tmp/setup/solr-extension.sh
 
 # Keep our image size down..
 pecl clear-cache

--- a/root/tmp/setup/solr-extension.sh
+++ b/root/tmp/setup/solr-extension.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install 2.4.0 release version + macports patch. Only combination working right now.
+# See #16 and #19 for more information.
+hash=6e9e097c981e810d452657f23bf1945b7955f3cf
+patch=https://raw.githubusercontent.com/macports/macports-ports/master/php/php-solr/files/php72.patch
+
+# Download our 'tagged' source code from git.
+echo "Downloading solr extension source archive (${hash})"
+curl --location \
+    https://github.com/php/pecl-search_engine-solr/archive/${hash}.tar.gz \
+    -o /tmp/pecl-search_engine-solr-${hash}.tar.gz
+
+# Download patch
+if [ -n $patch ]; then
+    curl --location \
+        $patch \
+        -o /tmp/solr.patch
+fi
+
+# Extract the compressed archive.
+cd /tmp
+tar -xvzf pecl-search_engine-solr-${hash}.tar.gz
+cd pecl-search_engine-solr-${hash}
+
+# Apply the patch
+if [ -n $patch ]; then
+    patch -p0 < ../solr.patch
+fi
+
+# Compile the extension as required by a manual PECL installation.
+echo "Compile solr extension"
+phpize
+./configure
+make
+
+# Finally, install it.
+echo "Install solr extension"
+make install
+
+# Remove all the sources.
+echo "Cleanup temporary folder and files"
+rm /tmp/pecl-search_engine-solr-${hash} -rf
+rm /tmp/pecl-search_engine-solr-${hash}.tar.gz -f
+rm /tmp/solr.patch -f
+
+# Enable it.
+docker-php-ext-enable solr
+
+# Done with this hack.
+# Please, follow https://github.com/moodlehq/moodle-php-apache/issues/19.


### PR DESCRIPTION
Using 2.4.0 release + custom patch (from macports project) seems to
be the only working combination right now. Read the comments in the code
and the links there.

Resolves solr issue in #16, waiting for the upstream as described in #19

This is basically a backport of #58 that was applied
to php72 and up.

The problem with php71 was detected @ https://github.com/moodlehq/moodle-docker/pull/134#issuecomment-691329406