### PR TITLE
Adding xmlrpc-beta now that 1.0.0RC2 has been released

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-apache-buster
+FROM php:8.0.1-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -62,14 +62,9 @@ docker-php-ext-install -j$(nproc) gd
 docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 docker-php-ext-install -j$(nproc) ldap
 
-# Memcached, MongoDB, Redis, APCu, igbinary, solr, uuid.
-pecl install memcached mongodb redis apcu igbinary solr uuid
-docker-php-ext-enable memcached mongodb redis apcu igbinary solr uuid
-
-# xmlrpc -- not existing as of 8.0.0 release (not yet @ PECL, https://php.watch/versions/  8.0#xmlrpc)
-# (once available add it to the previous pecl command)
-#pecl install xmlrpc
-#docker-php-ext-enable xmlrpc
+# APCu, igbinary, Memcached, MongoDB, Redis, Solr, uuid, XMLRPC (beta)
+pecl install apcu igbinary memcached mongodb redis solr uuid xmlrpc-beta
+docker-php-ext-enable apcu igbinary memcached mongodb redis solr uuid xmlrpc
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
 

--- a/tests/fixtures/test.php
+++ b/tests/fixtures/test.php
@@ -16,10 +16,10 @@ $requiredextensions = [
     'sodium',
     'solr',
     'sqlsrv',
+    'uuid',
     'xsl',
-    // 'xmlrpc', -- not existing as of 8.0.0 release (not yet @ PECL, https://php.watch/versions/8.0#xmlrpc)
+    'xmlrpc',
     'zip',
-    'uuid'
 ];
 
 $buffer = '';;


### PR DESCRIPTION
Link: https://pecl.php.net/package/xmlrpc

Note: RC1 had a packaging bug making it unusable, see https://bugs.php.net/bug.php?id=80618

Also, bump to 8.0.1