### PR TITLE
Bump to php 8.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.1-apache-buster
+FROM php:8.0-apache-buster
 
 ADD root/ /
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.


### PR DESCRIPTION
(by moving to 8.0-apache-buster "floating" tag)

Note this is just to reconcile master with the more modern version available, that is 8.0-buster right now.

Please merge this at very least 1-hour after merging #128. This is a requirement to verify one thing about the default description shown @ https://hub.docker.com/r/moodlehq/moodle-php-apache

1. When #128 is merged and DockerHub builds it... then the description is the 8.0-buster one.
2. 1 hour later, when this is merged and DockerHub builds this... then the description is back to the (complete, all versions) master one.

Just need to confirm this behavior to finish some auto-builders that will be in charge of schedule rebuilds of the images, planning to, always, put master the last one in order to get the complete description as is right now.

Ciao :-) 