### PR TITLE
First php 7.4 debian bullseye (11) build

### DIFF
--- a/.github/workflows/test_buildx_and_publish.yml
+++ b/.github/workflows/test_buildx_and_publish.yml
@@ -55,7 +55,7 @@ jobs:
             latest=false
           tags: |
             type=raw,value={{branch}}
-            type=match,pattern=(\d+.\d+),value={{branch}}
+            # Not the default yet (buster is): type=match,pattern=(\d+.\d+),value={{branch}}
 
       # https://github.com/docker/setup-qemu-action#usage
       - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache-buster
+FROM php:7.4-apache-bullseye
 
 # So we can use it anywhere for conditional stuff. Keeping BC with old (non-buildkit, builders)
 ARG TARGETPLATFORM

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Moodle PHP environment configured for Moodle development based on [Official PH
 
 | PHP Version  | Variant | Tags             | Status |
 |--------------|---------|------------------|--------|
-| PHP 7.4      | Buster  | 7.4, 7.4-buster  | [![Test and publish 7.4](https://github.com/moodlehq/moodle-php-apache/actions/workflows/test_buildx_and_publish.yml/badge.svg?branch=7.4-buster)](https://github.com/moodlehq/moodle-php-apache/actions/workflows/test_buildx_and_publish.yml)|
+| PHP 7.4      | Bullseye| 7.4-bullseye     | [![Test and publish 7.4](https://github.com/moodlehq/moodle-php-apache/actions/workflows/test_buildx_and_publish.yml/badge.svg?branch=7.4-bullseye)](https://github.com/moodlehq/moodle-php-apache/actions/workflows/test_buildx_and_publish.yml)|
 
 For a complete list of supported versions, look to the [master README](https://github.com/moodlehq/moodle-php-apache/tree/master).
 

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -6,7 +6,7 @@ echo "Installing apt dependencies"
 
 # Build packages will be added during the build, but will be removed at the end.
 BUILD_PACKAGES="gettext gnupg libcurl4-openssl-dev libfreetype6-dev libicu-dev libjpeg62-turbo-dev \
-  libldap2-dev libmariadbclient-dev libmemcached-dev libpng-dev libpq-dev libxml2-dev libxslt-dev \
+  libldap2-dev libmariadb-dev libmemcached-dev libpng-dev libpq-dev libxml2-dev libxslt-dev \
   unixodbc-dev uuid-dev"
 
 # Packages for Postgres.
@@ -16,7 +16,7 @@ PACKAGES_POSTGRES="libpq5"
 PACKAGES_MYMARIA="libmariadb3"
 
 # Packages for other Moodle runtime dependenices.
-PACKAGES_RUNTIME="ghostscript libaio1 libcurl4 libgss3 libicu63 libmcrypt-dev libxml2 libxslt1.1 \
+PACKAGES_RUNTIME="ghostscript libaio1 libcurl4 libgss3 libicu67 libmcrypt-dev libxml2 libxslt1.1 \
   libzip-dev locales sassc unixodbc unzip zip"
 
 # Packages for Memcached.

--- a/root/tmp/setup/sqlsrv-extension.sh
+++ b/root/tmp/setup/sqlsrv-extension.sh
@@ -7,7 +7,8 @@ set -e
 # https://github.com/Microsoft/msphpsql/wiki/Install-and-configuration#user-content-odbc-17-linux-installation
 echo "Downloading sqlsrv files"
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-curl https://packages.microsoft.com/config/debian/9/prod.list -o /etc/apt/sources.list.d/mssql-release.list
+# TODO, bullseye should be 11, but the msodbcsql17 package is not available yet, hence using buster (10) one.
+curl https://packages.microsoft.com/config/debian/10/prod.list -o /etc/apt/sources.list.d/mssql-release.list
 apt-get update
 
 echo "Install msodbcsql"


### PR DESCRIPTION
Note we still keep buster as default, so this only will build
the 7.4-bullseye tag.

Part of https://github.com/moodlehq/moodle-php-apache/issues/136

Creating the PR because it's passing tests locally and would be great to have it available to run a battery of DEV jobs @ ci.moodle.org and verify that everything is ok.

Once that's checked... another PR will switch defaults, making bullseye the new default one, relegating buster to 2nd line.

