### PR TITLE
Streamline the build of the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM}"
 
-ADD root/ /
-# Fix the original permissions of /tmp, the PHP default upload tmp dir.
-RUN chmod 777 /tmp && chmod +t /tmp
-
 # Install some packages that are useful within the images.
 RUN apt-get update && apt-get install -y \
     git \
@@ -30,11 +26,24 @@ RUN apt-get update && apt-get install -y \
 
 # Setup the required extensions.
 ARG DEBIAN_FRONTEND=noninteractive
+ADD root/tmp/setup/php-extensions.sh /tmp/setup/php-extensions.sh
 RUN /tmp/setup/php-extensions.sh
+
+# Install Oracle Instantclient
+ADD root/tmp/setup/oci8-extension.sh /tmp/setup/oci8-extension.sh
 RUN /tmp/setup/oci8-extension.sh
 ENV LD_LIBRARY_PATH /usr/local/instantclient
+
+# Install Microsoft sqlsrv.
+ADD root/tmp/setup/sqlsrv-extension.sh /tmp/setup/sqlsrv-extension.sh
+RUN /tmp/setup/sqlsrv-extension.sh
 
 RUN mkdir /var/www/moodledata && chown www-data /var/www/moodledata && \
     mkdir /var/www/phpunitdata && chown www-data /var/www/phpunitdata && \
     mkdir /var/www/behatdata && chown www-data /var/www/behatdata && \
     mkdir /var/www/behatfaildumps && chown www-data /var/www/behatfaildumps
+
+ADD root/usr /usr
+
+# Fix the original permissions of /tmp, the PHP default upload tmp dir.
+RUN chmod 777 /tmp && chmod +t /tmp

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -5,9 +5,9 @@ set -e
 echo "Installing apt dependencies"
 
 # Build packages will be added during the build, but will be removed at the end.
-BUILD_PACKAGES="gettext gnupg libcurl4-openssl-dev libfreetype6-dev libicu-dev libjpeg62-turbo-dev \
+BUILD_PACKAGES="gettext libcurl4-openssl-dev libfreetype6-dev libicu-dev libjpeg62-turbo-dev \
   libldap2-dev libmariadb-dev libmemcached-dev libpng-dev libpq-dev libxml2-dev libxslt-dev \
-  unixodbc-dev uuid-dev"
+  uuid-dev"
 
 # Packages for Postgres.
 PACKAGES_POSTGRES="libpq5"
@@ -17,7 +17,7 @@ PACKAGES_MYMARIA="libmariadb3"
 
 # Packages for other Moodle runtime dependenices.
 PACKAGES_RUNTIME="ghostscript libaio1 libcurl4 libgss3 libicu67 libmcrypt-dev libxml2 libxslt1.1 \
-  libzip-dev locales sassc unixodbc unzip zip"
+  libzip-dev locales sassc unzip zip"
 
 # Packages for Memcached.
 PACKAGES_MEMCACHED="libmemcached11 libmemcachedutil2"
@@ -73,15 +73,6 @@ echo "pcov.enabled=0" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 echo "pcov.exclude='~\/(tests|coverage|vendor|node_modules)\/~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 echo "pcov.directory=." >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 echo "pcov.initial.files=1024" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
-
-# Install Microsoft dependencies for sqlsrv.
-# (kept apart for clarity, still need to be run here
-# before some build packages are deleted)
-if [[ ${TARGETPLATFORM} == "linux/amd64" ]]; then
-    /tmp/setup/sqlsrv-extension.sh
-else
-    echo "sqlsrv extension not available for ${TARGETPLATFORM} architecture, skipping"
-fi
 
 # Keep our image size down..
 pecl clear-cache

--- a/root/tmp/setup/sqlsrv-extension.sh
+++ b/root/tmp/setup/sqlsrv-extension.sh
@@ -2,6 +2,25 @@
 
 set -e
 
+if [[ ${TARGETPLATFORM} != "linux/amd64" ]]; then
+  echo "sqlsrv extension not available for ${TARGETPLATFORM} architecture, skipping"
+  exit 0
+fi
+
+# Packages for build.
+BUILD_PACKAGES="gnupg unixodbc-dev"
+
+# Packages for sqlsrv runtime.
+PACKAGES_SQLSRV="unixodbc"
+
+# Note: These dependencies must be installed before installing the Microsoft source because there is a package in there
+# which breaks the install.
+echo "Installing apt dependencies"
+apt-get update
+apt-get install -y --no-install-recommends apt-transport-https \
+    $BUILD_PACKAGES \
+    $PACKAGES_SQLSRV
+
 # Install Microsoft dependencies for sqlsrv
 echo "Downloading sqlsrv files"
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
@@ -17,3 +36,10 @@ ln -fsv /opt/mssql-tools/bin/* /usr/bin
 # Need 5.10.1 (or later) for PHP 8.2 support
 pecl install sqlsrv-5.10.1
 docker-php-ext-enable sqlsrv
+
+# Keep our image size down..
+pecl clear-cache
+apt-get remove --purge -y $BUILD_PACKAGES
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This change makes it much faster to make smaller changes to the image by:
- moving the ADD commands to more targeted additions in order of build size
- breaking out the Oracle and sqlsrv builds into their own ADD and RUN sections in the Dockerfile
- moving the addition of non build-related files to right at the end of the Dockerfile

These changes mean that it is possible to more easily develop the image, for example:
- you can now make changes to files within the /usr directory without recompiling all PHP extensions
- you can now iterate on the Oracle and/or sqlsrv extensions without recompiling all PHP extensinos
- you can now iterate on the sqlsrv extension, without recompiling all PHP extensions, or Oracle

Whist this has little effect on the end image, or the build process within CI systems, local development is substantially improved (unless you're making changes to the php-extensions.sh script).