### PR TITLE
Build sqlsrv for ARM architectures too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
 RUN echo "Building for ${TARGETPLATFORM}"
 
-ADD root/ /
-# Fix the original permissions of /tmp, the PHP default upload tmp dir.
-RUN chmod 777 /tmp && chmod +t /tmp
-
 # Install some packages that are useful within the images.
 RUN apt-get update && apt-get install -y \
     git \
@@ -30,11 +26,24 @@ RUN apt-get update && apt-get install -y \
 
 # Setup the required extensions.
 ARG DEBIAN_FRONTEND=noninteractive
+ADD root/tmp/setup/php-extensions.sh /tmp/setup/php-extensions.sh
 RUN /tmp/setup/php-extensions.sh
+
+# Install Oracle Instantclient
+ADD root/tmp/setup/oci8-extension.sh /tmp/setup/oci8-extension.sh
 RUN /tmp/setup/oci8-extension.sh
 ENV LD_LIBRARY_PATH /usr/local/instantclient
+
+# Install Microsoft sqlsrv.
+ADD root/tmp/setup/sqlsrv-extension.sh /tmp/setup/sqlsrv-extension.sh
+RUN /tmp/setup/sqlsrv-extension.sh
 
 RUN mkdir /var/www/moodledata && chown www-data /var/www/moodledata && \
     mkdir /var/www/phpunitdata && chown www-data /var/www/phpunitdata && \
     mkdir /var/www/behatdata && chown www-data /var/www/behatdata && \
     mkdir /var/www/behatfaildumps && chown www-data /var/www/behatfaildumps
+
+ADD root/usr /usr
+
+# Fix the original permissions of /tmp, the PHP default upload tmp dir.
+RUN chmod 777 /tmp && chmod +t /tmp

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -5,9 +5,9 @@ set -e
 echo "Installing apt dependencies"
 
 # Build packages will be added during the build, but will be removed at the end.
-BUILD_PACKAGES="gettext gnupg libcurl4-openssl-dev libfreetype6-dev libicu-dev libjpeg62-turbo-dev \
+BUILD_PACKAGES="gettext libcurl4-openssl-dev libfreetype6-dev libicu-dev libjpeg62-turbo-dev \
   libldap2-dev libmariadb-dev libmemcached-dev libpng-dev libpq-dev libxml2-dev libxslt-dev \
-  unixodbc-dev uuid-dev"
+  uuid-dev"
 
 # Packages for Postgres.
 PACKAGES_POSTGRES="libpq5"
@@ -17,7 +17,7 @@ PACKAGES_MYMARIA="libmariadb3"
 
 # Packages for other Moodle runtime dependenices.
 PACKAGES_RUNTIME="ghostscript libaio1 libcurl4 libgss3 libicu67 libmcrypt-dev libxml2 libxslt1.1 \
-  libzip-dev locales sassc unixodbc unzip zip"
+  libzip-dev locales sassc unzip zip"
 
 # Packages for Memcached.
 PACKAGES_MEMCACHED="libmemcached11 libmemcachedutil2"
@@ -73,15 +73,6 @@ echo "pcov.enabled=0" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 echo "pcov.exclude='~\/(tests|coverage|vendor|node_modules)\/~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 echo "pcov.directory=." >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 echo "pcov.initial.files=1024" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
-
-# Install Microsoft dependencies for sqlsrv.
-# (kept apart for clarity, still need to be run here
-# before some build packages are deleted)
-if [[ ${TARGETPLATFORM} == "linux/amd64" ]]; then
-    /tmp/setup/sqlsrv-extension.sh
-else
-    echo "sqlsrv extension not available for ${TARGETPLATFORM} architecture, skipping"
-fi
 
 # Keep our image size down..
 pecl clear-cache

--- a/root/tmp/setup/sqlsrv-extension.sh
+++ b/root/tmp/setup/sqlsrv-extension.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [[ ${TARGETPLATFORM} != "linux/amd64" ]]; then
-  echo "sqlsrv extension not available for ${TARGETPLATFORM} architecture, skipping"
-  exit 0
-fi
-
 # Packages for build.
 BUILD_PACKAGES="gnupg unixodbc-dev"
 
@@ -24,17 +19,16 @@ apt-get install -y --no-install-recommends apt-transport-https \
 # Install Microsoft dependencies for sqlsrv
 echo "Downloading sqlsrv files"
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-# TODO, bullseye should be 11, but the msodbcsql17 package is not available yet, hence using buster (10) one.
-curl https://packages.microsoft.com/config/debian/10/prod.list -o /etc/apt/sources.list.d/mssql-release.list
+curl https://packages.microsoft.com/config/debian/11/prod.list -o /etc/apt/sources.list.d/mssql-release.list
 apt-get update
 
 echo "Install msodbcsql"
-ACCEPT_EULA=Y apt-get install -y msodbcsql17
+ACCEPT_EULA=Y apt-get install -y msodbcsql18
 
 ln -fsv /opt/mssql-tools/bin/* /usr/bin
 
-# Need 5.10.1 (or later) for PHP 8.2 support
-pecl install sqlsrv-5.10.1
+# Need 5.11.0 (or later) for PHP 8.2 support
+pecl install sqlsrv-5.11.0
 docker-php-ext-enable sqlsrv
 
 # Keep our image size down..

--- a/root/tmp/setup/sqlsrv-extension.sh
+++ b/root/tmp/setup/sqlsrv-extension.sh
@@ -2,6 +2,25 @@
 
 set -e
 
+if [[ ${TARGETPLATFORM} != "linux/amd64" ]]; then
+  echo "sqlsrv extension not available for ${TARGETPLATFORM} architecture, skipping"
+  exit 0
+fi
+
+# Packages for build.
+BUILD_PACKAGES="gnupg unixodbc-dev"
+
+# Packages for sqlsrv runtime.
+PACKAGES_SQLSRV="unixodbc"
+
+# Note: These dependencies must be installed before installing the Microsoft source because there is a package in there
+# which breaks the install.
+echo "Installing apt dependencies"
+apt-get update
+apt-get install -y --no-install-recommends apt-transport-https \
+    $BUILD_PACKAGES \
+    $PACKAGES_SQLSRV
+
 # Install Microsoft dependencies for sqlsrv
 echo "Downloading sqlsrv files"
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
@@ -17,3 +36,10 @@ ln -fsv /opt/mssql-tools/bin/* /usr/bin
 # Need 5.10.1 (or later) for PHP 8.2 support
 pecl install sqlsrv-5.10.1
 docker-php-ext-enable sqlsrv
+
+# Keep our image size down..
+pecl clear-cache
+apt-get remove --purge -y $BUILD_PACKAGES
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The `msodbcsql18` package is now available under the MS Bullseye repository, and they've added support for some new architectures.

The new `Release` file offers the following architecture support:
```
Architectures: amd64 arm64 armhf all
```

I'm not sure on how the driver version may affect us, but according to the (SQL version compatibility table)[https://learn.microsoft.com/en-us/sql/connect/odbc/windows/system-requirements-installation-and-driver-files?view=sql-server-ver16]:
- msodbcsql17 supports SQL Server 2012 and up
- msodbcsql18 18.0 supports SQL Server 2014 and up
- msodbcsql18 18.1 supports SQL Server 2014 and up

At the same time, Moodle 3.10 dropped support for SQL Server 2012.

Moodle 3.9 only supports PHP 7.2 - PHP 7.4.
Moodle 3.11 supports PHP 7.3 - 8.0
Moodle 4.00 supports PHP 7.3 - 8.0
Moodle 4.01 supports PHP 7.3 - 8.1
Moodle 4.02 supports PHP 8.0 - 8.2

I think we're safe to bump the msodbsql version to 18 for PHP 8.0 and up.