### PR TITLE
Increase max upload size

### DIFF
--- a/.github/workflows/test_buildx_and_publish.yml
+++ b/.github/workflows/test_buildx_and_publish.yml
@@ -31,6 +31,7 @@ jobs:
               -e PHP_INI-apc.enabled=0 \
               -e PHP_INI-apc.enable_cli=0 \
               -e PHP_INI-pcov.enabled=1 \
+              -e PHP_INI-upload_max_filesize=20M \
               moodle-php-apache
           docker exec test0 php /var/www/html/test.php
           docker exec test0 php /var/www/html/check-ini.php

--- a/root/usr/local/bin/moodle-docker-php-ini
+++ b/root/usr/local/bin/moodle-docker-php-ini
@@ -4,7 +4,7 @@ set -e
 
 echo "Checking for php configuration in environment"
 
-localinifile="/usr/local/etc/php/conf.d/10-local.ini"
+localinifile="/usr/local/etc/php/conf.d/20-local.ini"
 
 cat <<'EOF' > $localinifile
 ; --

--- a/root/usr/local/etc/php/conf.d/10-docker-php-moodle.ini
+++ b/root/usr/local/etc/php/conf.d/10-docker-php-moodle.ini
@@ -4,3 +4,10 @@
 ; See MDL-71390 for more info. This is the recommended / required
 ; value to support sites having 1000 courses, activities, users....
 max_input_vars = 5000
+
+; Increase the maximum filesize to 200M, which is a more realistic figure.
+upload_max_filesize = 200M
+
+; Increase the maximum post size to accomodate the increased upload_max_filesize.
+; The default value is 6MB more than the default upload_max_filesize.
+post_max_size = 206M

--- a/tests/fixtures/check-ini.php
+++ b/tests/fixtures/check-ini.php
@@ -1,17 +1,17 @@
 <?php
 
-$fileuploads = ini_get('file_uploads');
-$apcenabled = ini_get('apc.enabled');
-$memorylimit = ini_get('memory_limit');
 
 $allokay = true;
 $message = [];
+
+$fileuploads = ini_get('file_uploads');
 if (!empty($fileuploads)) {
     $allokay = false;
     $message[] = "Uploads are enabled and should be disabled.";
     $message[] = var_export($fileuploads, true);
 }
 
+$apcenabled = ini_get('apc.enabled');
 if (!empty($apcenabled)) {
     $allokay = false;
     $message[] = "apc.enabled is not Off (0): ({$apcenabled})";
@@ -23,6 +23,7 @@ if (!empty($apcenabledcli)) {
     $message[] = "apc.enabled_cli is not Off (0): ({$apcenabledcli})";
 }
 
+$memorylimit = ini_get('memory_limit');
 if ($memorylimit !== '256M') {
     $allokay = false;
     $message[] = "Memory limit not set to 256M: ({$memorylimit})";
@@ -32,6 +33,18 @@ $pcovenabled = ini_get('pcov.enabled');
 if (empty($pcovenabled)) {
     $allokay = false;
     $message[] = "pcov.enabled is not On (1): ({$pcovenabled})";
+}
+
+$maxuploadsize = ini_get('upload_max_filesize');
+if ($maxuploadsize !== '20M') {
+    $allokay = false;
+    $message[] = "Maximum upload size not set to 20M: ({$maxuploadsize})";
+}
+
+$postmaxsize = ini_get('post_max_size');
+if ($postmaxsize !== '206M') {
+    $allokay = false;
+    $message[] = "Maximum post size not set to 206M: ({$postmaxsize})";
 }
 
 if (php_sapi_name() === 'cli') {


### PR DESCRIPTION
This increases the standard maximum upload file size to 200M, which is a much more realistic size for development.

This also requires a bump in the maximum post size.