### PR TITLE
Install xdebug and xhprof as standard

### DIFF
--- a/.github/workflows/test_buildx_and_publish.yml
+++ b/.github/workflows/test_buildx_and_publish.yml
@@ -32,6 +32,7 @@ jobs:
               -e PHP_INI-apc.enable_cli=0 \
               -e PHP_INI-pcov.enabled=1 \
               -e PHP_INI-upload_max_filesize=20M \
+              -e PHP_EXTENSION_xhprof=1 \
               moodle-php-apache
           docker exec test0 php /var/www/html/test.php
           docker exec test0 php /var/www/html/check-ini.php

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ docker run --name web0 -p 8080:80  -v $PWD:/var/www/html moodlehq/moodle-php-a
 * Verified by [automated tests](https://travis-ci.com/moodlehq/moodle-php-apache).
 * Autobuilt from GHA, on push.
 * Support for entrypoint scripts and PHP Configuration
+* Many common extensions available
 
 ## Directories
 To facilitate testing and easy setup the following directories are created and owned by www-data by default:
@@ -90,7 +91,71 @@ docker run \
     moodle-php-apache:latest
 ```
 
+## Extensions
+
+The following extensions are inluded as standard:
+
+* apcu
+* exif
+* gd
+* igbinary
+* intl
+* ldap
+* memcached
+* mysqli
+* oci8
+* opcache
+* pcov
+* pgsql
+* redis
+* soap
+* solr
+* sqlsrv
+* timezonedb
+* uuid
+* xdebug
+* xhprof
+* xsl
+* zip
+
+All of the above extensions are enabled by default, except for:
+
+* pcov
+* xdebug
+* xhprof
+
+### Enabling optional extensions
+
+Several extensions are installed, but not enabled. You can enable them easily.
+
+### xdebug
+
+The `xdebug` extension can be enabled by specifying the following environment variable when starting the container:
+
+```bash
+PHP_EXTENSION_xdebug=1
+```
+
+### xhprof
+
+The `xdebug` extension can be enabled by specifying the following environment variable when starting the container:
+
+```bash
+PHP_EXTENSION_xhprof=1
+```
+
+#### pcov
+
+The `pcov` extension is typically not used in the web UI, but is widely used for code coverage generation in unit testing.
+
+It can be enabled by specifying the following environment variable when starting the container:
+
+```bash
+PHP_INI-pcov.enabled=1
+```
+
 ## See also
+
 This container is part of a set of containers for Moodle development, see also:
 
 * [moodle-docker](https://github.com/moodlehq/moodle-docker) a docker-composer based set of tools to get Moodle development running with zero configuration

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -64,6 +64,9 @@ docker-php-ext-enable apcu igbinary memcached pcov redis timezonedb uuid
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/10-docker-php-ext-apcu.ini
 
+# Install, but do not enable, xdebug and xhprof.
+pecl install xdebug xhprof
+
 echo "pcov.enabled=0" >> /usr/local/etc/php/conf.d/10-docker-php-ext-pcov.ini
 echo "pcov.exclude='~\/(tests|coverage|vendor|node_modules)\/~'" >> /usr/local/etc/php/conf.d/10-docker-php-ext-pcov.ini
 echo "pcov.directory=." >> /usr/local/etc/php/conf.d/10-docker-php-ext-pcov.ini

--- a/root/usr/local/bin/moodle-docker-php-ini
+++ b/root/usr/local/bin/moodle-docker-php-ini
@@ -26,4 +26,15 @@ $name = $value
 
 EOF
   fi
+
+  if [[ $fullname = PHP_EXTENSION_* ]]; then
+    extension=`echo $fullname | sed 's/^PHP_EXTENSION_//'`
+    echo "=> Found extension to enable: '${extension}'"
+    if [[ -f "/usr/local/etc/php/conf.d/docker-php-ext-${extension}.ini" ]]; then
+      echo "=> Extension already enabled: '${extension}'"
+    else
+      echo "=> Enabling extension '${extension}'"
+      docker-php-ext-enable ${extension}
+    fi
+  fi
 done

--- a/tests/fixtures/check-ini.php
+++ b/tests/fixtures/check-ini.php
@@ -1,6 +1,5 @@
 <?php
 
-
 $allokay = true;
 $message = [];
 
@@ -45,6 +44,18 @@ $postmaxsize = ini_get('post_max_size');
 if ($postmaxsize !== '206M') {
     $allokay = false;
     $message[] = "Maximum post size not set to 206M: ({$postmaxsize})";
+}
+
+$xhprof = extension_loaded('xhprof');
+if (!$xhprof) {
+    $allokay = false;
+    $message[] = "xhprof extension not loaded (should be enabled)";
+}
+
+$xdebug = extension_loaded('xdebug');
+if ($xdebug) {
+    $allokay = false;
+    $message[] = "xdebug extension loaded (should be disabled)";
 }
 
 if (php_sapi_name() === 'cli') {


### PR DESCRIPTION
This also adds a new PHP_EXTENSION-[name]=1 environment variable optino to call docker-php-ext-enable on start.