### PR TITLE
Split locales generation out from php extensions installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,12 @@ RUN apt-get update && apt-get install -y \
 # For an example of php80-rc5 near complete, using pickle instead of pear/pecl, look to:
 # https://github.com/stronk7/moodle-php-apache/tree/8.0-buster-pickle-version
 
-# Setup the required extensions.
+# Generate all the UTF-8 locales.
 ARG DEBIAN_FRONTEND=noninteractive
+ADD root/tmp/setup/locales-gen.sh /tmp/setup/locales-gen.sh
+RUN /tmp/setup/locales-gen.sh
+
+# Setup the required extensions.
 ADD root/tmp/setup/php-extensions.sh /tmp/setup/php-extensions.sh
 RUN /tmp/setup/php-extensions.sh
 

--- a/root/tmp/setup/locales-gen.sh
+++ b/root/tmp/setup/locales-gen.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Installing apt dependencies"
+
+# Packages for installing locales.
+RUNTIME_LOCALES="locales"
+
+apt-get update
+apt-get install -y --no-install-recommends apt-transport-https \
+    $RUNTIME_LOCALES
+
+echo "Installing UTF-8 locales"
+
+# Generate the locales configuration for all possible UTF-8 locales.
+grep UTF-8 /usr/share/i18n/SUPPORTED > /etc/locale.gen
+locale-gen
+
+# Keep our image size down..
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -17,7 +17,7 @@ PACKAGES_MYMARIA="libmariadb3"
 
 # Packages for other Moodle runtime dependenices.
 PACKAGES_RUNTIME="ghostscript libaio1 libcurl4 libgss3 libicu67 libmcrypt-dev libxml2 libxslt1.1 \
-  libzip-dev locales sassc unzip zip"
+  libzip-dev sassc unzip zip"
 
 # Packages for Memcached.
 PACKAGES_MEMCACHED="libmemcached11 libmemcachedutil2"
@@ -33,11 +33,6 @@ apt-get install -y --no-install-recommends apt-transport-https \
     $PACKAGES_RUNTIME \
     $PACKAGES_MEMCACHED \
     $PACKAGES_LDAP
-
-# Generate the locales configuration for all possible UTF-8 locales.
-echo 'Generating locales..'
-grep UTF-8 /usr/share/i18n/SUPPORTED > /etc/locale.gen
-locale-gen
 
 echo "Installing php extensions"
 


### PR DESCRIPTION
When trying to modify the php installed extensions in the images it's a pain to have to wait for all the locales to be generated.

So, the changes here just split that responsibility to another, separated layer that will be cached before playing with extensions.

If accepted, I'll spread the change over all the versions... 

Ciao :-)