### PR TITLE
Ensure that all the output on bootstrap goes to stderr

### DIFF
--- a/.github/workflows/test_buildx_and_publish.yml
+++ b/.github/workflows/test_buildx_and_publish.yml
@@ -39,6 +39,12 @@ jobs:
           docker exec test0 php /var/www/html/check-entrypoint-scripts.php
           curl --fail http://127.0.0.1:8000/test.php
           curl --fail http://127.0.0.1:8000/check-ini.php
+          # Verify that CLI execution only includes the expected output (if we discard stderr).
+          stdout=$(docker run --rm --name test1 moodle-php-apache php /var/www/html/check-stderr.php 2>/dev/null)
+          [[ ${stdout} == "Hello World!" ]] && echo "OK" || echo "Fail"
+          # Verify that stderr still contains information about the bootstrap.
+          stdout=$(docker run --rm --name test1 moodle-php-apache php /var/www/html/check-stderr.php 2>&1)
+          [[ ${stdout} =~ "Checking for php configuration" ]] && echo "OK" || echo "Fail"
 
       - name: Display container logs on failure
         if: failure()

--- a/root/usr/local/bin/moodle-docker-php-entrypoint
+++ b/root/usr/local/bin/moodle-docker-php-entrypoint
@@ -12,29 +12,26 @@ docker_process_init_files() {
         rm -f /tmp/testscript
         cp "$f" /tmp/testscript
         if [ -x "/tmp/testscript" ]; then
-          echo "$0: running $f"
+          echo "$0: running $f" >/dev/stderr
           "$f"
         else
-          echo "$0: sourcing $f"
+          echo "$0: sourcing $f" >/dev/stderr
           . "$f"
         fi
         ;;
       *.ini)
-        echo "$0: copying $f into /usr/local/etc/php/conf.d/"
+        echo "$0: copying $f into /usr/local/etc/php/conf.d/" >/dev/stderr
         cp "$f" /usr/local/etc/php/conf.d/
         ;;
     esac
   done
 }
 
-echo "Running PHP Configuration fetcher"
+echo "Running PHP Configuration fetcher" >/dev/stderr
 /usr/local/bin/moodle-docker-php-ini
-echo
 
-echo "Running entrypoint files from /docker-entrypoint.d/*"
+echo "Running entrypoint files from /docker-entrypoint.d/*" >/dev/stderr
 docker_process_init_files /docker-entrypoint.d/*
-echo
 
-echo "Starting docker-php-entrypoint with $@"
+echo "Starting docker-php-entrypoint with $@" >/dev/stderr
 source /usr/local/bin/docker-php-entrypoint
-echo

--- a/root/usr/local/bin/moodle-docker-php-ini
+++ b/root/usr/local/bin/moodle-docker-php-ini
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "Checking for php configuration in environment"
+echo "Checking for php configuration in environment" >/dev/stderr
 
 localinifile="/usr/local/etc/php/conf.d/20-local.ini"
 
@@ -18,7 +18,7 @@ env | while IFS= read -r line; do
   fullname=${line%%=*}
   if [[ $fullname = PHP_INI-* ]]; then
     name=`echo $fullname | sed 's/^PHP_INI-//'`
-    echo "=> Found '${name}' with value '${value}'"
+    echo "=> Found '${name}' with value '${value}'" >/dev/stderr
 
     cat << EOF >> $localinifile
 ; $fullname=$value
@@ -29,11 +29,11 @@ EOF
 
   if [[ $fullname = PHP_EXTENSION_* ]]; then
     extension=`echo $fullname | sed 's/^PHP_EXTENSION_//'`
-    echo "=> Found extension to enable: '${extension}'"
+    echo "=> Found extension to enable: '${extension}'" >/dev/stderr
     if [[ -f "/usr/local/etc/php/conf.d/docker-php-ext-${extension}.ini" ]]; then
-      echo "=> Extension already enabled: '${extension}'"
+      echo "=> Extension already enabled: '${extension}'" >/dev/stderr
     else
-      echo "=> Enabling extension '${extension}'"
+      echo "=> Enabling extension '${extension}'" >/dev/stderr
       docker-php-ext-enable ${extension}
     fi
   fi

--- a/tests/fixtures/check-stderr.php
+++ b/tests/fixtures/check-stderr.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "Hello World!";


### PR DESCRIPTION
That way we can filter out it if needed, for example if we just want to instantiate a php container to run a php script, we don't want all the bootstrap (entrypoint, ini config...) information to pollute the execution. That way, this will work as expected:

```
$ docker run --rm moodlehq/moodle-php-apache php -r 'echo "Hi!" . PHP_EOL;' 2>/dev/null
Hi!
```

And, without discarding stderr, we still get all the information (stdout + stderr):

```
$ docker run --rm moodlehq/moodle-php-apache php -r 'echo "Hi!" . PHP_EOL;'
Running PHP Configuration fetcher
Checking for php configuration in environment
Running entrypoint files from /docker-entrypoint.d/*
Starting docker-php-entrypoint with php -r echo "Hi!" . PHP_EOL;
Hi!
```

The only alternative to the above that I can imagine is to completely suppress any output (to both stdout and stderr) in out bootstrap.

Note that I've also tried to send the information to Apache error log, but that was futile, because the images have error.log as alias of stderr.