### PR TITLE
Enable igbinary serializer for redis

### DIFF
--- a/root/tmp/setup/php-extensions.sh
+++ b/root/tmp/setup/php-extensions.sh
@@ -59,10 +59,14 @@ docker-php-ext-install -j$(nproc) ldap
 
 # APCu, igbinary, Memcached, PCov, Redis, Solr, timezonedb, uuid
 # Note: Missing as of 2023-06-17: solr
-pecl install apcu igbinary memcached pcov redis timezonedb uuid
-docker-php-ext-enable apcu igbinary memcached pcov redis timezonedb uuid
+pecl install apcu igbinary memcached pcov timezonedb uuid
+docker-php-ext-enable apcu igbinary memcached pcov timezonedb uuid
 
 echo 'apc.enable_cli = On' >> /usr/local/etc/php/conf.d/10-docker-php-ext-apcu.ini
+
+# Install the redis extension enabling igbinary support.
+pecl install --configureoptions 'enable-redis-igbinary="yes"' redis
+docker-php-ext-enable redis
 
 # Install, but do not enable, xdebug and xhprof.
 pecl install xdebug xhprof

--- a/tests/fixtures/test.php
+++ b/tests/fixtures/test.php
@@ -40,6 +40,10 @@ foreach ($locales as $locale) {
 }
 setlocale(LC_TIME, 'en_AU.UTF-8');
 
+if (!defined('\Redis::SERIALIZER_IGBINARY')) {
+    $missing[] = 'redis support for igbinary serializer';
+}
+
 if (php_sapi_name() === 'cli') {
     if (empty($missing)) {
         echo "OK\n";


### PR DESCRIPTION
It comes disabled by default and Moodle does support to use it as alternative serializer. Covered with test.

Fixes #182

Once this is accepted I'll backport this to all PHP 8.0, 8.1 and 8.2 images.