### PR TITLE
Recommend to use the latest version in the example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A Moodle PHP environment configured for Moodle development based on [Official PH
 ## Example usage
 The following command will expose the current working directory on port 8080:
 ```bash
-$ docker run --name web0 -p 8080:80  -v $PWD:/var/www/html moodlehq/moodle-php-apache:7.1
+$ docker run --name web0 -p 8080:80  -v $PWD:/var/www/html moodlehq/moodle-php-apache:8.3
 ```
 
 ## Features


### PR DESCRIPTION
And later, after https://github.com/moodlehq/moodle-php-apache/issues/188 is fixed, we should update this again so this example code permanently references the latest available version.