### PR TITLE
Use the Moodle Router as a FallbackResource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN mkdir /var/www/moodledata && chown www-data /var/www/moodledata && \
     mkdir /var/www/.nvm && chown www-data /var/www/.nvm
 
 ADD root/usr /usr
+ADD root/etc /etc
 
 # Fix the original permissions of /tmp, the PHP default upload tmp dir.
 RUN chmod 777 /tmp && chmod +t /tmp

--- a/root/etc/apache2/conf-enabled/fallback.conf
+++ b/root/etc/apache2/conf-enabled/fallback.conf
@@ -1,0 +1,3 @@
+<Location "/">
+  FallbackResource /r.php
+</Location>


### PR DESCRIPTION
Needs to be applied to 8.1, 8.2, and 8.3.