### PR TITLE
Use locales-all instead of building all locales every build

### DIFF
--- a/root/tmp/setup/locales-gen.sh
+++ b/root/tmp/setup/locales-gen.sh
@@ -5,17 +5,11 @@ set -e
 echo "Installing apt dependencies"
 
 # Packages for installing locales.
-RUNTIME_LOCALES="locales"
+RUNTIME_LOCALES="locales locales-all"
 
 apt-get update
 apt-get install -y --no-install-recommends apt-transport-https \
     $RUNTIME_LOCALES
-
-echo "Installing UTF-8 locales"
-
-# Generate the locales configuration for all possible UTF-8 locales.
-grep UTF-8 /usr/share/i18n/SUPPORTED > /etc/locale.gen
-locale-gen
 
 # Keep our image size down..
 apt-get autoremove -y


### PR DESCRIPTION
This change modifies the images to use the `locales-all` debian package which installs all locales using pre-generated data. This shaves about 40 minutes from every build at the cost of about 13MB of image size.

https://packages.debian.org/bookworm/amd64/locales-all/filelist