### PR TITLE
Set zend.exception_ignore_args config per recommendations.

### DIFF
--- a/root/usr/local/etc/php/conf.d/10-docker-php-moodle.ini
+++ b/root/usr/local/etc/php/conf.d/10-docker-php-moodle.ini
@@ -11,3 +11,7 @@ upload_max_filesize = 200M
 ; Increase the maximum post size to accomodate the increased upload_max_filesize.
 ; The default value is 6MB more than the default upload_max_filesize.
 post_max_size = 206M
+
+; It is strongly recommended that the PHP setting zend.exception_ignore_args be
+; enabled as a security precaution. See environment check from MDL-84918.
+zend.exception_ignore_args = 1


### PR DESCRIPTION
Fixes the environment check for sites using this image, see [MDL-84918](https://moodle.atlassian.net/browse/MDL-84918)

[MDL-84918]: https://moodle.atlassian.net/browse/MDL-84918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ